### PR TITLE
remove the trailing new line in NIX_LD

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ be done with a `shell.nix` in a nix-shell like this:
     openssl
     # ...
   ];
-  NIX_LD = builtins.readFile "${stdenv.cc}/nix-support/dynamic-linker";
+  NIX_LD = lib.fileContents "${stdenv.cc}/nix-support/dynamic-linker";
 }
 ```
 


### PR DESCRIPTION
There is a trailing new line in the dynamic-linker file. This should be removed.

$ nix eval --impure --expr 'with import <nixpkgs> {}; builtins.readFile "${stdenv.cc}/nix-support/dynamic-linker"'
"/nix/store/0c7c96gikmzv87i7lv3vq5s1cmfjd6zf-glibc-2.31-74/lib/ld-linux-x86-64.so.2\n"

$ nix eval --impure --expr 'with import <nixpkgs> {}; lib.fileContents "${stdenv.cc}/nix-support/dynamic-linker"'
"/nix/store/0c7c96gikmzv87i7lv3vq5s1cmfjd6zf-glibc-2.31-74/lib/ld-linux-x86-64.so.2"