### PR TITLE
print errors to stderr

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,7 @@
+cut_body_after = "" # don't include text from the PR body in the merge commit message
+status = [
+  "Evaluate flake.nix",
+  "check smoketest [x86_64-linux]",
+  "package default [x86_64-linux]",
+  "package nix-ld [x86_64-linux]"
+]

--- a/src/nix-ld.c
+++ b/src/nix-ld.c
@@ -56,14 +56,14 @@ static inline void munmapp(mmap_t *m) {
 
 static void log_error(struct ld_ctx *ctx, const char *format, ...) {
   va_list args;
-  printf("cannot execute %s: ", ctx->prog_name);
+  fprintf(stderr, "cannot execute %s: ", ctx->prog_name);
 
   va_start(args, format);
-  vfprintf(stdout, format, args);
+  vfprintf(stderr, format, args);
   va_end(args);
 
   // cannot overflow because vsnprintf leaves space for the null byte
-  printf("\n");
+  fprintf(stderr, "\n");
 }
 
 static char *get_env(char* env, const char* key) {


### PR DESCRIPTION
programs are more likely to swallow stdout than stderr.